### PR TITLE
feat: RF03 - #WS39 - Incluí o campo de data de criação na listagem

### DIFF
--- a/app/service/alert.py
+++ b/app/service/alert.py
@@ -34,7 +34,7 @@ class AlertService:
                 m.value AS measure_value,
                 ws."name" AS station_name,
                 ta."name" AS type_alert_name,
-                a.create_date
+                to_timestamp(a.create_date) AS create_date
             FROM alerts a
             JOIN measures m
                 ON m.id = a.measure_id
@@ -68,7 +68,7 @@ class AlertService:
                 m.value as measure_value,
                 ws."name" as station_name,
                 ta."name" as type_alert_name,
-                a.create_date
+                to_timestamp(a.create_date) as create_date
             from alerts a
             join measures m
                 on m.id = a.measure_id


### PR DESCRIPTION
Atualizei as queries para retornar o campo create_date usando TO_TIMESTAMP, permitindo que o frontend receba a data no formato ISO 8601.
